### PR TITLE
pin release for php-http/message

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,7 +7,7 @@ FROM "${DOCKER_HUB_PROXY}composer:2.1.14" as composer-build
     RUN composer install --ignore-platform-reqs && \
      composer require jakub-onderka/openid-connect-php:1.0.0-rc1 --ignore-platform-reqs && \
      composer require --with-all-dependencies supervisorphp/supervisor:^4.0 \
-      guzzlehttp/guzzle php-http/message lstrojny/fxmlrpc --ignore-platform-reqs && \
+      guzzlehttp/guzzle php-http/message:1.13.0 lstrojny/fxmlrpc --ignore-platform-reqs && \
      composer require --with-all-dependencies elasticsearch/elasticsearch:^8.7.0 aws/aws-sdk-php --ignore-platform-reqs
 
 FROM "${DOCKER_HUB_PROXY}debian:bullseye-slim" as php-build


### PR DESCRIPTION
pinned to 1.13.0 in order to use workers with new Background Jobs