### PR TITLE
Add/document AUTOGEN_ADMIN_KEY, AUTOCONF_GPG, MISP_EMAIL, MISP_CONTACT

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Pull the entire repository, you can build the images using `docker-compose build
 
 Once you have the docker container up you can access the container by running `docker-compose exec misp /bin/bash`.
 This will provide you with a root shell. You can use `apt update` and then install any tools you wish to use.
-Finally, copy any changes you make outside of the container for commiting to your branch. 
+Finally, copy any changes you make outside of the container for commiting to your branch.
 `git diff -- [dir with changes]` could be used to reduce the number of changes in a patch file, however, be careful when using the `git diff` command.
 
 ### Updating
@@ -92,7 +92,7 @@ Updating the images should be as simple as `docker-compose pull` which, unless c
 
 ### Building
 
-If you are interested in building the project from scratch - `git clone` or download the entire repo and run `docker-compose build` 
+If you are interested in building the project from scratch - `git clone` or download the entire repo and run `docker-compose build`
 
 ## Image file sizes
 
@@ -114,7 +114,7 @@ The `docker-compose.yml` file allows further configuration settings:
 ```
 "MYSQL_HOST=db"
 "MYSQL_USER=misp"
-"MYSQL_PASSWORD=example"    # NOTE: This should be AlphaNum with no Special Chars. Otherwise, edit config files after first run. 
+"MYSQL_PASSWORD=example"    # NOTE: This should be AlphaNum with no Special Chars. Otherwise, edit config files after first run.
 "MYSQL_DATABASE=misp"
 "MISP_MODULES_FQDN=http://misp-modules" # Set the MISP Modules FQDN, used for Enrichment_services_url/Import_services_url/Export_services_url
 "WORKERS=1"                 # Legacy variable controlling the number of parallel workers (use variables below instead)

--- a/template.env
+++ b/template.env
@@ -1,24 +1,25 @@
 MISP_TAG=v2.4.174
 MODULES_TAG=v2.4.174
 PHP_VER=20190902
+
 # MISP_COMMIT takes precedence over MISP_TAG
 # MISP_COMMIT=c56d537
 # MODULES_COMMIT takes precedence over MODULES_TAG
 # MODULES_COMMIT=de69ae3
 
-# default to MISP's default (admin@admin.test)
+# Email/username for user #1, defaults to MISP's default (admin@admin.test)
 ADMIN_EMAIL=
-# default to MISP's default (Org1)
+# name of org #1, default to MISP's default (ORGNAME)
 ADMIN_ORG=
-# default to an automatically generated one
+# defaults to an automatically generated one
 ADMIN_KEY=
-# default to MISP's default (admin)
+# defaults to MISP's default (admin)
 ADMIN_PASSWORD=
-# default to 'passphrase'
+# defaults to 'passphrase'
 GPG_PASSPHRASE=
-# default to 1 (the admin user)
+# defaults to 1 (the admin user)
 CRON_USER_ID=
-# default to 'https://localhost'
+# defaults to 'https://localhost'
 HOSTNAME=
 
 # optional and used by the mail sub-system
@@ -28,10 +29,30 @@ SMARTHOST_USER=
 SMARTHOST_PASSWORD=
 SMARTHOST_ALIASES=
 
-# comma separated list of IDs of syncservers (e.g. SYNCSERVERS=1)
+# optional comma separated list of IDs of syncservers (e.g. SYNCSERVERS=1)
+# For this to work ADMIN_KEY must be set, or AUTOGEN_ADMIN_KEY must be true (default)
 SYNCSERVERS=
 # note: if you have more than one syncserver, you need to update docker-compose.yml
 SYNCSERVERS_1_URL=
 SYNCSERVERS_1_NAME=
 SYNCSERVERS_1_UUID=
 SYNCSERVERS_1_KEY=
+
+# These variables allows overriding some MISP email values.
+# They all default to ADMIN_EMAIL.
+
+# MISP.email, used for notifications. Also used
+# for GnuPG.email and GPG autogeneration.
+# MISP_EMAIL=
+
+# MISP.contact, the e-mail address that
+# MISP should include as a contact address
+# for the instance's support team.
+# MISP_CONTACT=
+
+# Enable GPG autogeneration (default true)
+# AUTOCONF_GPG=true
+
+# Enable admin (user #1) API key autogeneration
+# if ADMIN_KEY is not set above (default true)
+# AUTOGEN_ADMIN_KEY=true


### PR DESCRIPTION
- AUTOCONF_ADMIN_KEY renamed to AUTOGEN_ADMIN_KEY.
  - If ADMIN_KEY is set, that will still be set, AUTOGEN_ADMIN_KEY only turns off automatic generation.
- AUTOCONF_GPG behaves as before.
- MISP_EMAIL sets MISP.email and GPG-related email.
- MISP_CONTACT sets MISP.contact (support email)