### PR TITLE
Allow deferring nginx live flip through env var

### DIFF
--- a/server/files/entrypoint_nginx.sh
+++ b/server/files/entrypoint_nginx.sh
@@ -230,7 +230,10 @@ nginx -g 'daemon off;' & master_pid=$!
 echo "INIT | Initialize MISP files and configurations ..." && init_misp_data_files
 echo "INIT | Update MISP app/files directory ..." && update_misp_data_files
 echo "INIT | Enforce MISP permissions ..." && enforce_misp_data_permissions
-echo "INIT | Flip NGINX live ..." && flip_nginx true true
+
+if [[ -z "$DEFER_NGINX_FLIP" ]]; then
+    echo "INIT | Flip NGINX live ..." && flip_nginx true true
+fi
 
 # Run configure MISP script
 echo "INIT | Configure MISP installation ..."


### PR DESCRIPTION
Being able to defer flipping nginx live is useful if one wants to perform some time consuming tasks during customize_misp.sh

This PR simply adds an environment variable `DEFER_NGINX_FLIP` to allow performing this at a later stage in the init process.

The default behaviour is unchanged (flipping just before configure_misp.sh is run)