### PR TITLE
Also publish MISP version tag when pushing docker images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -40,7 +40,7 @@ group "default" {
 target "misp-modules" {
   context = "modules/."
   dockerfile = "Dockerfile"
-  tags = ["${DOCKER_USERNAME}/misp-docker:modules-latest", "${DOCKER_USERNAME}/misp-docker:modules-${DOCKER_IMG_TAG}"]
+  tags = ["${DOCKER_USERNAME}/misp-docker:modules-latest", "${DOCKER_USERNAME}/misp-docker:modules-${DOCKER_IMG_TAG}", "${DOCKER_USERNAME}/misp-docker:modules-${MODULES_TAG}"]
   args = {
     "MODULES_TAG": "${MODULES_TAG}",
     "MODULES_COMMIT": "${MODULES_COMMIT}"
@@ -51,7 +51,7 @@ target "misp-modules" {
 target "misp" {
   context = "server/."
   dockerfile = "Dockerfile"
-  tags = ["${DOCKER_USERNAME}/misp-docker:core-latest", "${DOCKER_USERNAME}/misp-docker:core-${DOCKER_IMG_TAG}"]
+  tags = ["${DOCKER_USERNAME}/misp-docker:core-latest", "${DOCKER_USERNAME}/misp-docker:core-${DOCKER_IMG_TAG}", "${DOCKER_USERNAME}/misp-docker:core-${MISP_TAG}"]
   args = {
     "MISP_TAG": "${MISP_TAG}",
     "MISP_COMMIT": "${MISP_COMMIT}",


### PR DESCRIPTION
Use $MODULES_TAG and $MISP_TAG to tag the respective images in addition to sha prefix.